### PR TITLE
Clean up application.yaml by removing unused config

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,11 +24,6 @@ spring:
     import: "optional:configtree:/mnt/secrets/rpe/"
   application:
     name: service-cp-crime-scheduleandlist-courtschedule
-#  azure:
-#    cosmos:
-#      endpoint: ${COSMOSDB_ENDPOINT}
-#      key: ${COSMOSDB_KEY}
-#      database: ${COSMOSDB_DATABASE}
 
 service:
   case-mapper-service:


### PR DESCRIPTION
Removed commented-out config but the real purpose of doing this is to ensure gitleaks fails the build

