### PR TITLE
Migrate to centralised live-import CLAUDE.md system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ applicationinsights-agent-*.jar
 .DS_Store
 */.DS_Store
 
-.env.claude/CLAUDE.md
+.env
+.claude/CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ applicationinsights-agent-*.jar
 .DS_Store
 */.DS_Store
 
-.env
+.env.claude/CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ uk.gov.hmcts.cp/
 ## Repo-Specific Architecture Rules
 
 - **HearingResponseFilter**: Applied before `HearingsMapper` — it normalises or removes backend fields that should not appear in the API response. Modify the filter (not the mapper) to change what fields are included.
-- **CJSCPPUID header**: `CourtScheduleClient` sets `CJSCPPUID` on every backend request. Never remove this header.
+- **CJSCPPUID header**: `CourtScheduleClient` sets `CJSCPPUID` on every backend request.
 - **Mapper is pure**: `HearingsMapper` only transforms types; no filtering or business logic.
 
 ## Debugging

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+## Repo: service-cp-crime-scheduleandlist-courtschedule
+
+Spring Boot service that retrieves court schedule data for a case URN by calling the CP backend, applies a hearing response filter to normalise the result, and returns it as an API response.
+
+**Pattern**: Stateless proxy with response filtering
+**Spring Boot version**: 4.0.1 (target 4.0.6+ per upgrade cycle)
+**Implements**: `api-cp-crime-schedulingandlisting-courtschedule`
+
+## Infrastructure
+
+| Component | Technology | Purpose |
+|---|---|---|
+| CP Backend | External HTTP | Source of court schedule data |
+| WireMock | 3.6.0 (docker) | Backend stub for local dev and API tests |
+
+## Source Structure
+
+```
+uk.gov.hmcts.cp/
+  Application.java                          @SpringBootApplication
+  clients/
+    CourtScheduleClient                     RestTemplate → CP backend; sets CJSCPPUID header
+  config/
+    AppConfig                               @Bean RestTemplate
+    AppPropertiesBackend                    @Value AMP_BACKEND_URL, CP_BACKEND_URL
+  controllers/
+    CourtScheduleController                 Implements generated API; delegates to CourtScheduleService
+    GlobalExceptionHandler                  @RestControllerAdvice; maps exceptions to HTTP codes
+    RootController                          Returns 200 on GET /
+  domain/
+    CaseMapperResponse                      Internal DTO: case URN → case ID
+    HearingResponse                         Internal DTO: raw hearing data from backend
+  exceptions/
+    GlobalExceptionHandler                  Maps domain exceptions to HTTP status codes
+  filters/
+    HearingResponseFilter                   Strips or transforms backend hearing fields before mapping
+    TracingFilter                           Reads/generates X-Correlation-Id; propagates via MDC
+  mappers/
+    HearingsMapper                          Maps HearingResponse domain DTO to API response model
+  services/
+    CaseUrnMapperService                    Resolves case URN to case ID via CP backend
+    CourtScheduleService                    Calls CourtScheduleClient → applies filter → maps response
+```
+
+## Environment Variables
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `CP_BACKEND_URL` | Base URL of the CP backend (court schedule data) | `http://localhost:8081` |
+| `AMP_BACKEND_URL` | Alternative backend URL (used by CaseUrnMapperService) | `http://localhost:8081` |
+| `CJSCPPUID` | User UUID header on all backend calls | `00000000-0000-0000-0000-000000000000` |
+| `rpe.AppInsightsInstrumentationKey` | Azure Application Insights key | `00000000-0000-0000-0000-000000000000` |
+
+## Repo-Specific Architecture Rules
+
+- **HearingResponseFilter**: Applied before `HearingsMapper` — it normalises or removes backend fields that should not appear in the API response. Modify the filter (not the mapper) to change what fields are included.
+- **CJSCPPUID header**: `CourtScheduleClient` sets `CJSCPPUID` on every backend request. Never remove this header.
+- **Mapper is pure**: `HearingsMapper` only transforms types; no filtering or business logic.
+
+## Debugging
+
+| Symptom | Cause / Fix |
+|---|---|
+| Missing hearings in response | Check `HearingResponseFilter` — fields may be stripped; review filter logic |
+| 404 for valid URN | Backend does not have schedule for that case; check `CP_BACKEND_URL` and data |
+| Null fields in response | `@JsonInclude(NON_NULL)` suppresses nulls; check whether backend returned the field |
+
+## Repo-Specific Notes
+
+- `ci-build-publish.yml` present alongside standard `ci-draft.yml` / `ci-released.yml`.
+- No database; fully stateless.


### PR DESCRIPTION
## Commits

```
e7b73f7 docs(claude): add repo context and fix shared imports
48db03d refactor: Bootstrap centralised live-import CLAUDE.md
```

## What changed (latest commit)

| File | Change |
|---|---|
| `CLAUDE.md` (new, committed) | Repo-specific service context: infrastructure (WireMock, CP backend), source structure (CourtScheduleClient, **HearingResponseFilter** that normalises backend fields before mapping, HearingsMapper — modify filter not mapper to control field exposure), environment variables (CP_BACKEND_URL, AMP_BACKEND_URL, CJSCPPUID, AppInsights), architecture rules (filter/mapper separation, mandatory CJSCPPUID header), debugging (missing hearings, null fields) |
| `.gitignore` | Fixed concatenation error: `.env.claude/CLAUDE.md` → split into `.env` + `.claude/CLAUDE.md` |

## Diff summary (latest commit)

```
2 files changed, 73 insertions(+), 1 deletion(-)
  CLAUDE.md     | 74 +++++++++++++++++++++++++++++++++++++++ (new)
  .gitignore    |  2 +-
```

## Context

Part of the HMCTS APIM centralised Claude context system. Content is runtime behaviour only — no generated interface/model class names (those live in `api-cp-crime-schedulingandlisting-courtschedule`). Shared standards live in `apim-claude-template` and are live-imported via the developer-local `.claude/CLAUDE.md` (gitignored, **3 lines**):

```
@../../apim-claude-template/templates/shared-code-rules.md
@../../apim-claude-template/templates/service-shared.md
@../../apim-claude-template/templates/claude-md-standards.md
```

Set up with `/wire-claude-context`. The committed `CLAUDE.md` here contains only runtime behaviour unique to this service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)